### PR TITLE
Mysql-workbench: remove python fix.

### DIFF
--- a/packages/dev-db/mysql-workbench/mysql-workbench-6.3.10.exheres-0
+++ b/packages/dev-db/mysql-workbench/mysql-workbench-6.3.10.exheres-0
@@ -69,11 +69,6 @@ src_prepare() {
             "${CMAKE_SOURCE}"/backend/wbpublic/grtui/*.h \
             "${CMAKE_SOURCE}"/backend/wbpublic/objimpl/db.query/*.cpp
 
-    # fix python detection
-    edo sed -i \
-            -e '/find_package(PythonLibs 2.6)/d' \
-            "${CMAKE_SOURCE}"/CMakeLists.txt
-
     # rm -Werror, fails due to -Wdeprecated
     edo sed -i \
             -e 's/\-Werror//' \


### PR DESCRIPTION
It seems that when cmake is asked to find python 2.6, it will also match python 2.7 if available. However, if the system has python 3 as default python, the "fix" won't let the package to compile.